### PR TITLE
add github link to footer & increase footer opacity

### DIFF
--- a/vegancity/static/css/partials/footer.css
+++ b/vegancity/static/css/partials/footer.css
@@ -8,7 +8,8 @@
     bottom: 0;
     left: 0;
     right: 0;
-    opacity: .7;
+    opacity: .9;
+    border-top: 1px solid #eee;
 }
 
 #footer ul {
@@ -47,5 +48,5 @@
 }
 
 #footer a {
-  margin-right: 20px;
+  margin-right: 8px;
 }

--- a/vegancity/templates/vegancity/partials/footer.html
+++ b/vegancity/templates/vegancity/partials/footer.html
@@ -4,5 +4,6 @@
       <li><a href="{% url 'about' %}">About</a></li>
       <li><a href="http://www.facebook.com/vegphilly"><i class="fa fa-facebook"></i></a></li>
       <li><a href="http://www.twitter.com/vegphilly"><i class="fa fa-twitter"></i></a></li>
+      <li><a href="//github.com/vegphilly/vegphilly.com"><i class="fa fa-github"></i></a></li>
     </ul>
 </div>


### PR DESCRIPTION
This PR adds a vegphilly github link to the footer, and increases the opacity of the footer background color so links within it are more readable. Solves this display issue:
<img width="901" alt="screen shot 2015-11-11 at 5 45 28 pm" src="https://cloud.githubusercontent.com/assets/2671157/11105338/35ef1d48-889c-11e5-892d-8e7ae9eac2dd.png">

Can you review, @steventlamb ? Thanks!
