### PR TITLE
development updates/fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,16 +21,19 @@ quickstart
 ----------
 
 This project is meant to be developed from within a virtualbox environment.  
-Please InstallVirtualbox and Vagrant for your OS.  
+Please Install VirtualBox (and VirtualBox Extension Pack) and Vagrant for your OS.  
 
 Navigate to the root of this project and run:  
-```vagrant up```
+```shell
+vagrant plugin install vagrant-vbguest
+vagrant up
+```
 
 This will create a virtual environment, install dependencies, provide you with  
 enough data to get coding right away, and fire up a runserver. Point your browser  
-to ```localhost:8000``` and start editing files.  
+to `localhost:8000` and start editing files.  
   
-When you're finished working on the site, just run ```vagrant halt``` to power down  
+When you're finished working on the site, just run `vagrant halt` to power down  
 the VM. The next time you start it up, it will purge any changes you made to the provided  
 data.  
 
@@ -49,29 +52,40 @@ FAQ
 
 Having trouble? Here's some common problems and solutions.  
 
+The password for the vagrant account is 'vagrant'.
+
 ### development server
-###### not running after ```vagrant up```
+###### not running after `vagrant up`
 at times, for one reason or another, the django runserver doesn't start on boot.  
-To start this manually, enter from the project room:
+To start this manually, enter from the project root:
 ```
 vagrant ssh
-sudo supervisorctl restart vegphilly-runserver
+
+# check if supervisord is running
+sudo supervisorctl status
+
+# if it isn't:
+sudo service supervisor restart
+
+# restart the dev daemon
+sudo supervisorctl restart vegdev
 ```
-The password for the vagrant account is 'vagrant'.
 
 ###### viewing the log in realtime
 normally a django runserver runs in your terminal for debugging. If you'd like to view
 the terminal to watch for output, execute:
 ```
 vagrant ssh
-cd /var/log/vegphilly/
-tail -f access.log
+tail -f /tmp/dev-access-error.log
 ```
 ###### stopping the server to free port 8000 for other things
-just run
+`supervisord` usually fails to kill the dev server it starts. After telling `supervisord`
+to stop `vegdev`, make sure to run the `killdev.py` script to clean up any zombie processes.
 ```
 vagrant ssh
-sudo supervisorctl stop vegphilly-runserver
+
+sudo supervisorctl stop vegdev
+/usr/local/vegphilly/killdev.py
 ```
 
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,7 @@
 VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "chef/debian-7.4"
+  config.vm.box = "debian/wheezy64"
 
   # for selenium tests
   config.ssh.forward_x11 = true

--- a/ansible/roles/dev/templates/dev_supervisor.conf.j2
+++ b/ansible/roles/dev/templates/dev_supervisor.conf.j2
@@ -1,7 +1,7 @@
-[program:vegphilly_detached_dev]
+[program:vegdev]
 directory = /usr/local/vegphilly/
 user = {{ app_user }}
 autorestart = true
-command = {{ project_dir }}/manage.py runserver 0.0.0.0:8888
-stdout_logfile = /tmp/detached-dev-access.log
-stderr_logfile = /tmp/detached-dev-error.log
+command = {{ project_dir }}/supervisord_rundev.sh
+redirect_stderr=true
+stdout_logfile = /tmp/dev-access-error.log

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -6,6 +6,7 @@ beautifulsoup4==4.3.1
 ipython==1.0.0
 ipdb==0.7
 django-debug-toolbar==1.2.1
+sqlparse==0.1.19
 django-debug-toolbar-template-timings==0.6.1
 selenium==2.35.0
 PyVirtualDisplay==0.1.2

--- a/killdev.py
+++ b/killdev.py
@@ -1,0 +1,52 @@
+#!/usr/bin/python
+#
+#~ kills django dev instances
+import sys
+import subprocess as p
+
+
+def get_procs(port=8000, user='vagrant'):
+    """find pids for runserver-processes running under `user` on `port`"""
+    proc = "manage.py runserver 0.0.0.0:{p}".format(p=port)
+    ps = p.check_output(['ps', 'aux']).split('\n')
+    procs = []
+    for line in ps:
+        if proc in line:
+            # line looks like:
+            # <user>   <pid>  <other junk>
+            info = line.strip().split(' ')
+            user_name = info[0]
+            if user_name != user:
+                continue
+            info = ' '.join(info[1:]).strip()
+            pid = info.split(' ')[0]
+            try:
+                pid = int(pid)
+            except ValueError:
+                continue
+            procs.append((pid, line))
+    return procs
+
+
+def main(port):
+    procs = get_procs(port=port)
+    for proc_info in procs:
+        pid, info = proc_info
+        kill = p.call(['kill', str(pid)])
+        if kill == 0:
+            print("Killed zombie 'runserver' running on port={}".format(port))
+        else:
+            print("Error occurred while trying to kill zombie 'runserver'")
+            sys.exit(2)
+
+
+if __name__ == '__main__':
+    args = sys.argv[1:]
+    port = 8000
+    if args:
+        try:
+            port = int(args[0])
+        except ValueError:
+            print("Usage: killdev.py [port-num] --- default: port-num=8000")
+    main(port)
+    sys.exit(0)

--- a/supervisord_rundev.sh
+++ b/supervisord_rundev.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# supervisord fails to kill the dev servers it spawns,
+# make sure they're all dead before starting a new one.
+/usr/local/vegphilly/killdev.py 8000
+/usr/local/vegphilly/manage.py runserver 0.0.0.0:8000


### PR DESCRIPTION
This fixes a bunch of stuff related to getting a development environment up and running. Running `vagrant up` should work as expected again.

- update the base vagrant box
- pin `sqlparse` in `dev_requirements` to get `debug_toolbar` working again
- change the `supervisord` dev name to `vegdev`, easier to type
- run the dev server on port `8000` instead of `8888`
- combine access & error dev logs to `/tmp/dev-access-error.log`
- update readme setup-directions/help
- deal with zombie `runserver`s
  - `supervisord` usually fails to kill it's runserver-processes
    when you tell it to `supervisorctl stop vegdev`
  - added a `killdev.py` script to cleanup zombies running on a given port
  - updated the `dev_supervisor.conf` to call `supervisord_rundev.sh`
    which runs `killdev.py` before starting up a new dev instance